### PR TITLE
Add tag override system with customizable blacklist and translations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,8 @@ data/usage_data.json
 classifiers/**/*.safetensors
 classifiers/**/tags.json
 
+# User-specific classifier overrides (example files are tracked)
+classifiers/*/overrides.toml
+
 # Temp files
 *.tmp

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ Use whichever model(s) you prefer. JTP-3 is recommended for best results.
 
 Models are optional - the app provides full manual tagging functionality without them.
 
+**Customizing Model Output**: Each model can have its own `overrides.toml` configuration file to blacklist unwanted tags or translate tag names (see `overrides.toml.example` files in classifier folders).
+
 ## File Structure
 
 ```

--- a/classifier_manager.py
+++ b/classifier_manager.py
@@ -418,6 +418,11 @@ class ClassifierManager(QObject):
     @Slot(list)
     def _handle_worker_result(self, results):
         print("MainThread: Received analysis_finished signal from worker.")
+
+        # Apply tag overrides (blacklist/translation) before emitting
+        from tail_tagger.classifier_overrides import TagOverrideManager
+        results = TagOverrideManager.apply_overrides(results, self.active_model_id)
+
         self.analysis_finished.emit(results) # Relay the signal
 
     @Slot(str)

--- a/classifiers/JTP-3/overrides.toml.example
+++ b/classifiers/JTP-3/overrides.toml.example
@@ -1,0 +1,42 @@
+# Tag Overrides for JTP-3 Classifier
+#
+# This file configures how classifier inference results are processed before display.
+# To use this file, copy/rename it to "overrides.toml" (remove the .example extension).
+#
+# Format notes:
+# - Tag names use underscores: "female_anthro" not "female anthro"
+# - Tag names are case-sensitive
+# - String values must be quoted: "dog" not dog
+# - Keys with special chars need quotes: "digital_media_(artwork)"
+
+# ============================================================================
+# TAG TRANSLATIONS
+# ============================================================================
+# Map original tag names to replacement tag names (one-to-one mapping)
+# Format: original_tag = "replacement_tag"
+#
+# Common use case: E621 renames one tag to another, but classifier was
+# trained after this change and outputs a different tag than what most 
+# furry image generation models were expecting. Allows for auto 'fix' 
+
+[translations]
+vulva = "pussy"
+
+# Uncomment additional translations as needed:
+# foo = "bar"
+# felid = "garfield"
+# "digital_media_(artwork)" = "example"
+
+# ============================================================================
+# TAG BLACKLIST
+# ============================================================================
+# Tags to completely remove from inference results.
+# Useful for removing rating tags or unwanted meta tags.
+
+[blacklist]
+tags = [
+    # Uncomment to remove rating tags from all results:
+    # "explicit",
+    # "questionable",
+    # "safe",
+]

--- a/classifiers/JTP_PILOT/overrides.toml.example
+++ b/classifiers/JTP_PILOT/overrides.toml.example
@@ -1,0 +1,41 @@
+# Tag Overrides for JTP_PILOT Classifier
+#
+# This file configures how classifier inference results are processed before display.
+# To use this file, copy/rename it to "overrides.toml" (remove the .example extension).
+#
+# Format notes:
+# - Tag names use underscores: "female_anthro" not "female anthro"
+# - Tag names are case-sensitive
+# - String values must be quoted: "dog" not dog
+# - Keys with special chars need quotes: "digital_media_(artwork)"
+
+# ============================================================================
+# TAG TRANSLATIONS
+# ============================================================================
+# Map original tag names to replacement tag names (one-to-one mapping)
+# Format: original_tag = "replacement_tag"
+#
+# Common use case: E621 renames one tag to another, but classifier was
+# trained after this change and outputs a different tag than what most 
+# furry image generation models were expecting. Allows for auto 'fix' 
+
+[translations]
+# Uncomment and modify examples as needed. Generally not needed for JTP_PILOT:
+# pussy = "vulva"
+# canid = "canine"
+# felid = "feline"
+# "digital_media_(artwork)" = "digital_media"
+
+# ============================================================================
+# TAG BLACKLIST
+# ============================================================================
+# Tags to completely remove from inference results.
+# Useful for removing any tags you'll NEVER want to see in your results.
+
+[blacklist]
+tags = [
+    # Example for formatting:
+    # "example1",
+    # "example2",
+    # "example3",
+]

--- a/classifiers/JTP_PILOT2/overrides.toml.example
+++ b/classifiers/JTP_PILOT2/overrides.toml.example
@@ -1,0 +1,41 @@
+# Tag Overrides for JTP_PILOT2 Classifier
+#
+# This file configures how classifier inference results are processed before display.
+# To use this file, copy/rename it to "overrides.toml" (remove the .example extension).
+#
+# Format notes:
+# - Tag names use underscores: "female_anthro" not "female anthro"
+# - Tag names are case-sensitive
+# - String values must be quoted: "dog" not dog
+# - Keys with special chars need quotes: "digital_media_(artwork)"
+
+# ============================================================================
+# TAG TRANSLATIONS
+# ============================================================================
+# Map original tag names to replacement tag names (one-to-one mapping)
+# Format: original_tag = "replacement_tag"
+#
+# Common use case: E621 renames one tag to another, but classifier was
+# trained after this change and outputs a different tag than what most 
+# furry image generation models were expecting. Allows for auto 'fix' 
+
+[translations]
+# Uncomment and modify examples as needed. Generally not needed for JTP_PILOT2:
+# pussy = "vulva"
+# canid = "canine"
+# felid = "feline"
+# "digital_media_(artwork)" = "digital_media"
+
+# ============================================================================
+# TAG BLACKLIST
+# ============================================================================
+# Tags to completely remove from inference results.
+# Useful for removing any tags you'll NEVER want to see in your results.
+
+[blacklist]
+tags = [
+    # Example for formatting:
+    # "example1",
+    # "example2",
+    # "example3",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ einops>=0.6.0
 numpy>=1.26,<3
 safetensors==0.4.2
 Pillow>=9.4.0
+tomli>=2.0.0; python_version < "3.11"

--- a/tail_tagger/classifier_overrides/__init__.py
+++ b/tail_tagger/classifier_overrides/__init__.py
@@ -1,0 +1,11 @@
+"""
+Classifier tag override system.
+
+Provides per-classifier configuration for:
+- Blacklisting unwanted tags (e.g., rating tags)
+- Translating tag names (e.g., vulva -> pussy for e621 compatibility)
+"""
+
+from tail_tagger.classifier_overrides.manager import TagOverrideManager
+
+__all__ = ["TagOverrideManager"]

--- a/tail_tagger/classifier_overrides/manager.py
+++ b/tail_tagger/classifier_overrides/manager.py
@@ -1,0 +1,188 @@
+"""
+Tag override manager for classifier results.
+
+Handles loading and applying per-classifier tag overrides including:
+- Blacklist: Remove unwanted tags from results
+- Translation: Rename tags to user-preferred names
+"""
+
+from pathlib import Path
+from typing import Optional
+
+try:
+    import tomllib  # Python 3.11+
+except ModuleNotFoundError:
+    import tomli as tomllib  # Python 3.10
+
+
+class TagOverrideManager:
+    """Manages tag overrides for classifier inference results."""
+
+    # Cache loaded configs to avoid re-reading files
+    _config_cache: dict[str, Optional[dict]] = {}
+
+    @classmethod
+    def apply_overrides(
+        cls,
+        results: list[tuple[str, float]],
+        model_id: str
+    ) -> list[tuple[str, float]]:
+        """
+        Apply tag overrides to classifier results.
+
+        Processing order:
+        1. Blacklist (remove unwanted tags)
+        2. Translation (rename tags)
+        3. Deduplication (merge duplicates, keep highest confidence)
+        4. Re-sort by confidence descending
+
+        Args:
+            results: List of (tag_name, score) tuples from classifier
+            model_id: Classifier model identifier (e.g., "JTP-3")
+
+        Returns:
+            Filtered and translated list of (tag_name, score) tuples
+        """
+        # Load config (returns None if missing or invalid)
+        config = cls._load_config(model_id)
+
+        if config is None:
+            # No overrides to apply, return original results
+            return results
+
+        # Extract configuration
+        blacklist_section = config.get("blacklist", {})
+        blacklist = set(blacklist_section.get("tags", []))
+        translations = config.get("translations", {})
+
+        # Step 1: Filter out blacklisted tags (on original tag names)
+        filtered = [
+            (tag, score) for tag, score in results
+            if tag not in blacklist
+        ]
+
+        # Step 2: Apply translations
+        translated = [
+            (translations.get(tag, tag), score)
+            for tag, score in filtered
+        ]
+
+        # Step 3: Deduplicate - keep highest confidence for each unique tag name
+        deduplicated: dict[str, float] = {}
+        for tag, score in translated:
+            if tag not in deduplicated or score > deduplicated[tag]:
+                deduplicated[tag] = score
+
+        # Step 4: Convert back to list and sort by confidence descending
+        result = [(tag, score) for tag, score in deduplicated.items()]
+        result.sort(key=lambda x: x[1], reverse=True)
+
+        return result
+
+    @classmethod
+    def _load_config(cls, model_id: str) -> Optional[dict]:
+        """
+        Load override config for a classifier model.
+
+        Looks for: classifiers/{model_id}/overrides.toml
+
+        Args:
+            model_id: Classifier model identifier
+
+        Returns:
+            Config dict or None if file missing/invalid
+        """
+        # Check cache first
+        if model_id in cls._config_cache:
+            return cls._config_cache[model_id]
+
+        # Determine config file path
+        config_path = Path("classifiers") / model_id / "overrides.toml"
+
+        # Missing config file is not an error (user may not need overrides)
+        if not config_path.exists():
+            cls._config_cache[model_id] = None
+            return None
+
+        # Try to load config
+        try:
+            with open(config_path, 'rb') as f:
+                config = tomllib.load(f)
+
+            # Validate config structure
+            cls._validate_config(config, config_path)
+
+            # Cache successful load
+            cls._config_cache[model_id] = config
+            return config
+
+        except Exception as e:
+            # Log warning but don't crash
+            print(f"[WARNING] Failed to load classifier overrides for '{model_id}': {e}")
+            print(f"[WARNING] Proceeding with inference without tag overrides")
+            print(f"[WARNING] Check {config_path} for syntax errors")
+
+            # Cache failure to avoid re-attempting
+            cls._config_cache[model_id] = None
+            return None
+
+    @classmethod
+    def _validate_config(cls, config: dict, config_path: Path) -> None:
+        """
+        Validate config structure.
+
+        Raises ValueError if config is malformed.
+        """
+        # Check top-level keys
+        valid_keys = {"translations", "blacklist"}
+        invalid_keys = set(config.keys()) - valid_keys
+        if invalid_keys:
+            raise ValueError(
+                f"Unknown config keys: {invalid_keys}. "
+                f"Valid keys: {valid_keys}"
+            )
+
+        # Validate translations section
+        if "translations" in config:
+            translations = config["translations"]
+            if not isinstance(translations, dict):
+                raise ValueError(
+                    "Config section 'translations' must be a table/dict"
+                )
+
+            # Check that values are strings
+            for key, value in translations.items():
+                if not isinstance(value, str):
+                    raise ValueError(
+                        f"Translation value for '{key}' must be a string, "
+                        f"got {type(value).__name__}"
+                    )
+
+        # Validate blacklist section
+        if "blacklist" in config:
+            blacklist = config["blacklist"]
+            if not isinstance(blacklist, dict):
+                raise ValueError(
+                    "Config section 'blacklist' must be a table/dict"
+                )
+
+            # Check for 'tags' key
+            if "tags" in blacklist:
+                tags = blacklist["tags"]
+                if not isinstance(tags, list):
+                    raise ValueError(
+                        "Config 'blacklist.tags' must be an array/list"
+                    )
+
+                # Check that items are strings
+                for i, item in enumerate(tags):
+                    if not isinstance(item, str):
+                        raise ValueError(
+                            f"Blacklist tag at index {i} must be a string, "
+                            f"got {type(item).__name__}"
+                        )
+
+    @classmethod
+    def clear_cache(cls) -> None:
+        """Clear cached configs (useful for testing or config reloading)."""
+        cls._config_cache.clear()


### PR DESCRIPTION
this is meant to address potential annoyances with image classifiers or to provide convenience to users.
Primarily, occasional tag switching in boorus can cause discrepancies between image taggers and image models.

This feature allows one to translate a tag on the fly during inference. It also allows you to set up custom blacklists if you never want certain tags to show up in the results

closes #16 